### PR TITLE
feat: bootstrap GlobalPost shipping module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/vendor/
+modules/globalpostshipping/vendor/
+modules/globalpostshipping/composer.lock
+*.zip
+*.tar
+.idea/
+.DS_Store

--- a/docs/database/globalpostshipping_schema.sql
+++ b/docs/database/globalpostshipping_schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `ps_globalpost_order` (
+  `id_globalpost_order` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `id_cart` INT UNSIGNED NOT NULL,
+  `id_order` INT UNSIGNED DEFAULT NULL,
+  `country_from` VARCHAR(2) NOT NULL,
+  `country_to` VARCHAR(2) NOT NULL,
+  `type` ENUM('docs','parcel') NOT NULL,
+  `tariff_key` VARCHAR(128) DEFAULT NULL,
+  `international_tariff_id` INT UNSIGNED DEFAULT NULL,
+  `price_uah` DECIMAL(20,6) DEFAULT NULL,
+  `price_eur` DECIMAL(20,6) DEFAULT NULL,
+  `estimate_in_days` INT UNSIGNED DEFAULT NULL,
+  `shipment_id` VARCHAR(128) DEFAULT NULL,
+  `ttn` VARCHAR(128) DEFAULT NULL,
+  `payload` LONGTEXT DEFAULT NULL,
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id_globalpost_order`),
+  UNIQUE KEY `idx_globalpost_order_shipment` (`shipment_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/modules/globalpostshipping/README.md
+++ b/modules/globalpostshipping/README.md
@@ -1,0 +1,43 @@
+# GlobalPost Shipping Module
+
+GlobalPost Shipping is a PrestaShop 8 compatible module that introduces database entities and scaffolding required for future integrations with the GlobalPost logistics platform.
+
+## Requirements
+
+- PHP 8.0 or 8.1
+- PrestaShop 8.0 or newer
+- MySQL 5.7+ / MariaDB 10.3+
+
+## Installation
+
+1. Copy the module folder `globalpostshipping` into your PrestaShop `/modules` directory or install it through the Module Manager by uploading the archive.
+2. In the PrestaShop back office, navigate to **Modules > Module Manager**.
+3. Locate **GlobalPost Shipping** and click **Install**.
+
+Upon installation the module will automatically create the database table `ps_globalpost_order` (prefix depends on your store configuration).
+
+## Uninstallation
+
+1. In the back office go to **Modules > Module Manager**.
+2. Find **GlobalPost Shipping** in the list of installed modules.
+3. Click **Uninstall** and confirm the prompt.
+
+The database table created by the module is dropped during uninstallation.
+
+## Configuration
+
+The current version of the module does not expose any configuration options. Future iterations will introduce settings for API credentials and shipment preferences.
+
+## Development
+
+Install Composer dependencies and enable PSR-4 autoloading with:
+
+```bash
+composer install
+```
+
+This command will generate the `vendor/` folder and the Composer autoloader used by PrestaShop when loading the module classes.
+
+## License
+
+This module is released under the Academic Free License 3.0 (AFL-3.0).

--- a/modules/globalpostshipping/composer.json
+++ b/modules/globalpostshipping/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "globalpost/globalpostshipping",
+    "description": "GlobalPost shipping integration for PrestaShop 8.",
+    "type": "prestashop-module",
+    "license": "AFL-3.0",
+    "authors": [
+        {
+            "name": "GlobalPost"
+        }
+    ],
+    "require": {
+        "php": "^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "GlobalPostShipping\\": "src/"
+        }
+    }
+}

--- a/modules/globalpostshipping/globalpostshipping.php
+++ b/modules/globalpostshipping/globalpostshipping.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * GlobalPost Shipping module.
+ *
+ * @author    GlobalPost
+ * @copyright 2024 GlobalPost
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
+use GlobalPostShipping\Installer\DatabaseInstaller;
+
+class Globalpostshipping extends Module
+{
+    /**
+     * List of hooks registered by the module.
+     *
+     * @var array
+     */
+    private $hooks = [
+        'actionValidateOrder',
+        'actionOrderGridDefinitionModifier',
+        'actionOrderGridDataModifier',
+        'displayAdminOrderMainBottom',
+    ];
+
+    public function __construct()
+    {
+        $this->name = 'globalpostshipping';
+        $this->tab = 'shipping_logistics';
+        $this->version = '0.1.0';
+        $this->author = 'GlobalPost';
+        $this->need_instance = 0;
+        $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => _PS_VERSION_];
+
+        parent::__construct();
+
+        $this->displayName = $this->l('GlobalPost Shipping');
+        $this->description = $this->l('Provides GlobalPost shipping services integration.');
+        $this->confirmUninstall = $this->l('Are you sure you want to uninstall the GlobalPost Shipping module?');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function install()
+    {
+        return parent::install()
+            && $this->registerHooks()
+            && $this->getDatabaseInstaller()->install();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uninstall()
+    {
+        return $this->getDatabaseInstaller()->uninstall()
+            && parent::uninstall();
+    }
+
+    /**
+     * Registers hooks declared in the module.
+     *
+     * @return bool
+     */
+    private function registerHooks()
+    {
+        $result = true;
+
+        foreach ($this->hooks as $hook) {
+            $result = $result && $this->registerHook($hook);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Retrieves the database installer service.
+     */
+    private function getDatabaseInstaller(): DatabaseInstaller
+    {
+        return new DatabaseInstaller(Db::getInstance(), _DB_PREFIX_, _MYSQL_ENGINE_);
+    }
+}

--- a/modules/globalpostshipping/src/Installer/DatabaseInstaller.php
+++ b/modules/globalpostshipping/src/Installer/DatabaseInstaller.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Handles database setup for the GlobalPost Shipping module.
+ */
+
+namespace GlobalPostShipping\Installer;
+
+use Db;
+
+class DatabaseInstaller
+{
+    /**
+     * @var Db
+     */
+    private $db;
+
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @var string
+     */
+    private $engine;
+
+    public function __construct(Db $db, string $prefix, string $engine)
+    {
+        $this->db = $db;
+        $this->prefix = $prefix;
+        $this->engine = $engine;
+    }
+
+    public function install(): bool
+    {
+        $sql = sprintf(
+            'CREATE TABLE IF NOT EXISTS `%1$s` (
+                `id_globalpost_order` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+                `id_cart` INT UNSIGNED NOT NULL,
+                `id_order` INT UNSIGNED DEFAULT NULL,
+                `country_from` VARCHAR(2) NOT NULL,
+                `country_to` VARCHAR(2) NOT NULL,
+                `type` ENUM(\'docs\', \'parcel\') NOT NULL,
+                `tariff_key` VARCHAR(128) DEFAULT NULL,
+                `international_tariff_id` INT UNSIGNED DEFAULT NULL,
+                `price_uah` DECIMAL(20,6) DEFAULT NULL,
+                `price_eur` DECIMAL(20,6) DEFAULT NULL,
+                `estimate_in_days` INT UNSIGNED DEFAULT NULL,
+                `shipment_id` VARCHAR(128) DEFAULT NULL,
+                `ttn` VARCHAR(128) DEFAULT NULL,
+                `payload` LONGTEXT DEFAULT NULL,
+                `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id_globalpost_order`),
+                UNIQUE KEY `idx_globalpost_order_shipment` (`shipment_id`)
+            ) ENGINE=%2$s DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
+            $this->getTableName(),
+            \pSQL($this->engine)
+        );
+
+        return $this->db->execute($sql);
+    }
+
+    public function uninstall(): bool
+    {
+        $sql = sprintf('DROP TABLE IF EXISTS `%s`', $this->getTableName());
+
+        return $this->db->execute($sql);
+    }
+
+    private function getTableName(): string
+    {
+        return sprintf('%sglobalpost_order', $this->prefix);
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,11 @@
 GlobalPost Starter
+==================
+
+This repository contains the source code for the **GlobalPost Shipping** PrestaShop module. The initial iteration delivers the scaffolding required to bootstrap further development:
+
+- Module registration for PrestaShop 8+
+- Composer/PSR-4 autoloading configuration
+- Database installer that manages the `ps_globalpost_order` table
+- Documentation and SQL schema dump for onboarding
+
+Refer to [`modules/globalpostshipping/README.md`](modules/globalpostshipping/README.md) for installation and usage instructions.


### PR DESCRIPTION
## Summary
- add the GlobalPost Shipping module scaffold compatible with PrestaShop 8
- implement database installer that manages the ps_globalpost_order table lifecycle
- provide composer autoloading, documentation, gitignore, and SQL schema dump for onboarding

## Testing
- php -l modules/globalpostshipping/globalpostshipping.php
- php -l modules/globalpostshipping/src/Installer/DatabaseInstaller.php

------
https://chatgpt.com/codex/tasks/task_b_68cbd4c231b483238f0fc3575bf48033