### PR TITLE
Add GlobalPost HTTP client SDK layer

### DIFF
--- a/examples/GlobalPostClientExamples.php
+++ b/examples/GlobalPostClientExamples.php
@@ -1,0 +1,57 @@
+<?php
+
+require_once __DIR__ . '/../modules/globalpostshipping/src/SDK/GlobalPostClient.php';
+require_once __DIR__ . '/../modules/globalpostshipping/src/SDK/CurlHttpTransport.php';
+require_once __DIR__ . '/../modules/globalpostshipping/src/SDK/NullLogger.php';
+
+use GlobalPostShipping\SDK\GlobalPostClient;
+use GlobalPostShipping\SDK\NullLogger;
+
+$token = 'your-test-token';
+$mode = GlobalPostClient::MODE_TEST;
+
+$client = new GlobalPostClient($token, $mode, [
+    'timeout' => 10,
+    'connect_timeout' => 5,
+    'max_retries' => 1,
+    'retry_delay' => 0.2,
+    'debug' => true,
+]);
+
+try {
+    $countries = $client->getCountries();
+    echo 'Supported countries: ' . implode(', ', $countries) . PHP_EOL;
+
+    $options = $client->getOptions([
+        'from_country' => 'UA',
+        'to_country' => 'US',
+        'weight' => 500,
+        'length' => 20,
+        'width' => 15,
+        'height' => 10,
+        'package_type' => 'parcel',
+    ]);
+
+    print_r($options);
+
+    $order = $client->createShortOrder([
+        'contragent_key' => 'your-contragent-key',
+        'international_tariff_id' => 123,
+        'order_id' => 'ORDER-42',
+        'recipient_country' => 'US',
+        'recipient_city' => 'New York',
+        'recipient_name' => 'John Doe',
+        'recipient_phone' => '+1000111222333',
+        'recipient_email' => 'customer@example.com',
+    ]);
+
+    print_r($order);
+
+    $label = $client->printLabel('en', 'ORDER-42');
+    file_put_contents(__DIR__ . '/label.pdf', $label);
+
+    $invoice = $client->printInvoice('ORDER-42');
+    file_put_contents(__DIR__ . '/invoice.pdf', $invoice);
+} catch (Exception $exception) {
+    echo 'GlobalPost error: ' . $exception->getMessage() . PHP_EOL;
+}

--- a/modules/globalpostshipping/src/SDK/CurlHttpTransport.php
+++ b/modules/globalpostshipping/src/SDK/CurlHttpTransport.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace GlobalPostShipping\SDK;
+
+use RuntimeException;
+
+class CurlHttpTransport implements HttpTransportInterface
+{
+    private float $timeout;
+
+    private float $connectTimeout;
+
+    public function __construct(float $timeout = 10.0, float $connectTimeout = 5.0)
+    {
+        if ($timeout <= 0.0) {
+            throw new RuntimeException('Timeout must be greater than zero.');
+        }
+
+        if ($connectTimeout <= 0.0) {
+            throw new RuntimeException('Connect timeout must be greater than zero.');
+        }
+
+        $this->timeout = $timeout;
+        $this->connectTimeout = $connectTimeout;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed> $options
+     */
+    public function request(string $method, string $url, array $headers = [], array $options = []): HttpResponse
+    {
+        $curl = curl_init();
+        if ($curl === false) {
+            throw new HttpTransportException('Unable to initialise cURL session.');
+        }
+
+        $encodedHeaders = [];
+        foreach ($headers as $name => $value) {
+            $encodedHeaders[] = $name . ': ' . $value;
+        }
+
+        $curlOptions = [
+            CURLOPT_URL => $url,
+            CURLOPT_CUSTOMREQUEST => strtoupper($method),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_TIMEOUT => $this->timeout,
+            CURLOPT_CONNECTTIMEOUT => $this->connectTimeout,
+            CURLOPT_HTTPHEADER => $encodedHeaders,
+            CURLOPT_HEADER => true,
+        ];
+
+        if (isset($options['body'])) {
+            $curlOptions[CURLOPT_POSTFIELDS] = $options['body'];
+        }
+
+        if (isset($options['verify']) && $options['verify'] === false) {
+            $curlOptions[CURLOPT_SSL_VERIFYPEER] = false;
+            $curlOptions[CURLOPT_SSL_VERIFYHOST] = 0;
+        }
+
+        if (!curl_setopt_array($curl, $curlOptions)) {
+            curl_close($curl);
+            throw new HttpTransportException('Failed to configure cURL session.');
+        }
+
+        $result = curl_exec($curl);
+        if ($result === false) {
+            $errorMessage = curl_error($curl);
+            $errorCode = curl_errno($curl);
+            curl_close($curl);
+            throw new HttpTransportException($errorMessage !== '' ? $errorMessage : 'Unknown cURL error.', $errorCode);
+        }
+
+        $statusCode = curl_getinfo($curl, CURLINFO_RESPONSE_CODE) ?: 0;
+        $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE) ?: 0;
+        curl_close($curl);
+
+        $rawHeaders = substr($result, 0, $headerSize);
+        $body = substr($result, $headerSize);
+
+        $headersArray = $this->parseHeaders($rawHeaders);
+
+        return new HttpResponse($statusCode, $headersArray, $body);
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    private function parseHeaders(string $rawHeaders): array
+    {
+        $headers = [];
+        $lines = preg_split('/\r?\n/', $rawHeaders) ?: [];
+        foreach ($lines as $line) {
+            if (strpos($line, ':') === false) {
+                continue;
+            }
+
+            [$name, $value] = explode(':', $line, 2);
+            $normalized = strtolower(trim($name));
+            if (!isset($headers[$normalized])) {
+                $headers[$normalized] = [];
+            }
+
+            $headers[$normalized][] = trim($value);
+        }
+
+        return $headers;
+    }
+}

--- a/modules/globalpostshipping/src/SDK/GlobalPostClient.php
+++ b/modules/globalpostshipping/src/SDK/GlobalPostClient.php
@@ -1,0 +1,381 @@
+<?php
+
+namespace GlobalPostShipping\SDK;
+
+use Throwable;
+
+class GlobalPostClient
+{
+    public const MODE_TEST = 'TEST';
+    public const MODE_PROD = 'PROD';
+
+    private const BASE_URLS = [
+        self::MODE_TEST => 'https://test-api.globalpost.com.ua',
+        self::MODE_PROD => 'https://api.globalpost.com.ua',
+    ];
+
+    private string $token;
+
+    private string $mode;
+
+    private string $baseUrl;
+
+    private HttpTransportInterface $transport;
+
+    private LoggerInterface $logger;
+
+    private bool $debug;
+
+    private int $maxRetries;
+
+    private float $retryDelay;
+
+    public function __construct(
+        string $token,
+        string $mode = self::MODE_TEST,
+        array $config = [],
+        ?HttpTransportInterface $transport = null,
+        ?LoggerInterface $logger = null
+    ) {
+        $normalizedMode = strtoupper($mode);
+        if (!isset(self::BASE_URLS[$normalizedMode])) {
+            $normalizedMode = self::MODE_TEST;
+        }
+
+        $this->token = trim($token);
+        $this->mode = $normalizedMode;
+        $this->baseUrl = self::BASE_URLS[$this->mode];
+        $timeout = isset($config['timeout']) ? (float) $config['timeout'] : 10.0;
+        $connectTimeout = isset($config['connect_timeout']) ? (float) $config['connect_timeout'] : 5.0;
+        $this->transport = $transport ?? new CurlHttpTransport($timeout, $connectTimeout);
+        $this->logger = $logger ?? new NullLogger();
+        $this->debug = (bool) ($config['debug'] ?? false);
+        $this->maxRetries = max(0, (int) ($config['max_retries'] ?? 1));
+        $this->retryDelay = max(0.0, (float) ($config['retry_delay'] ?? 0.5));
+    }
+
+    public function getMode(): string
+    {
+        return $this->mode;
+    }
+
+    public function getBaseUrl(): string
+    {
+        return $this->baseUrl;
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function getCountries(): array
+    {
+        $response = $this->performRequest('GET', '/public/tariff-international/countries');
+
+        return $this->decodeJson($response);
+    }
+
+    /**
+     * @param array<string, scalar|array<scalar>> $params
+     *
+     * @return array<int|string, mixed>
+     */
+    public function getOptions(array $params): array
+    {
+        $response = $this->performRequest('GET', '/public/tariff-international/get-options', [
+            'query' => $params,
+        ]);
+
+        return $this->decodeJson($response);
+    }
+
+    /**
+     * @param array<string, scalar|array<scalar>> $formData
+     *
+     * @return array<int|string, mixed>
+     */
+    public function createShortOrder(array $formData): array
+    {
+        $response = $this->performRequest('POST', '/api/create-short-order', [
+            'form_params' => $formData,
+            'headers' => [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ],
+        ]);
+
+        return $this->decodeJson($response);
+    }
+
+    public function printLabel(string $locale, string $orderId): string
+    {
+        $response = $this->performRequest('GET', sprintf('/api/orders/print-new/%s/%s', rawurlencode($locale), rawurlencode($orderId)), [
+            'headers' => [
+                'Accept' => 'application/pdf',
+            ],
+        ]);
+
+        return $response->getBody();
+    }
+
+    public function printInvoice(string $orderId): string
+    {
+        $response = $this->performRequest('GET', sprintf('/api/orders/print-invoice/%s', rawurlencode($orderId)), [
+            'headers' => [
+                'Accept' => 'application/pdf',
+            ],
+        ]);
+
+        return $response->getBody();
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function performRequest(string $method, string $path, array $options = []): HttpResponse
+    {
+        $url = rtrim($this->baseUrl, '/') . '/' . ltrim($path, '/');
+        $headers = [
+            'Authorization' => 'Bearer ' . $this->token,
+            'Accept' => $options['headers']['Accept'] ?? 'application/json',
+        ];
+
+        if (isset($options['headers'])) {
+            foreach ($options['headers'] as $name => $value) {
+                $headers[$name] = $value;
+            }
+        }
+
+        $query = $options['query'] ?? null;
+        if ($query !== null) {
+            $queryString = $this->buildQuery($query);
+            if ($queryString !== '') {
+                $url .= (strpos($url, '?') === false ? '?' : '&') . $queryString;
+            }
+        }
+
+        $body = null;
+        if (isset($options['form_params'])) {
+            $body = $this->buildQuery($options['form_params']);
+        } elseif (isset($options['body'])) {
+            $body = (string) $options['body'];
+        }
+
+        if ($body !== null && !isset($headers['Content-Type'])) {
+            $headers['Content-Type'] = 'application/json';
+        }
+
+        $attempt = 0;
+        $maxAttempts = $this->maxRetries + 1;
+        $lastException = null;
+
+        while ($attempt < $maxAttempts) {
+            $attempt++;
+            $this->logDebug('GlobalPost request', [
+                'method' => strtoupper($method),
+                'url' => $url,
+                'attempt' => $attempt,
+                'query_keys' => $query !== null ? array_keys((array) $query) : [],
+                'has_body' => $body !== null,
+            ]);
+
+            try {
+                $response = $this->transport->request($method, $url, $headers, [
+                    'body' => $body,
+                ]);
+            } catch (HttpTransportException $exception) {
+                if ($this->shouldRetryTransport($exception) && $attempt < $maxAttempts) {
+                    $this->logWarning('Retrying GlobalPost request after transport error.', [
+                        'attempt' => $attempt,
+                        'error_code' => $exception->getCode(),
+                    ]);
+                    $this->sleep();
+                    $lastException = $exception;
+                    continue;
+                }
+
+                throw new GlobalPostClientException(
+                    'Failed to call GlobalPost API: ' . $exception->getMessage(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    $exception
+                );
+            }
+
+            $status = $response->getStatusCode();
+            $this->logDebug('GlobalPost response', [
+                'status' => $status,
+                'attempt' => $attempt,
+            ]);
+
+            if ($this->shouldRetryStatus($status) && $attempt < $maxAttempts) {
+                $this->logWarning('Retrying GlobalPost request after HTTP error.', [
+                    'status' => $status,
+                    'attempt' => $attempt,
+                ]);
+                $this->sleep();
+                $lastException = null;
+                continue;
+            }
+
+            if ($status >= 400) {
+                throw $this->createExceptionFromResponse($response);
+            }
+
+            return $response;
+        }
+
+        if ($lastException instanceof Throwable) {
+            throw new GlobalPostClientException(
+                'GlobalPost API request failed after retries: ' . $lastException->getMessage(),
+                null,
+                null,
+                null,
+                null,
+                $lastException
+            );
+        }
+
+        throw new GlobalPostClientException('GlobalPost API request failed after retries.');
+    }
+
+    private function shouldRetryTransport(HttpTransportException $exception): bool
+    {
+        return in_array($exception->getCode(), [
+            CURLE_OPERATION_TIMEDOUT,
+            CURLE_COULDNT_CONNECT,
+            CURLE_COULDNT_RESOLVE_HOST,
+            CURLE_COULDNT_RESOLVE_PROXY,
+        ], true);
+    }
+
+    private function shouldRetryStatus(int $status): bool
+    {
+        return $status >= 500 && $status < 600;
+    }
+
+    private function sleep(): void
+    {
+        if ($this->retryDelay > 0) {
+            usleep((int) ($this->retryDelay * 1_000_000));
+        }
+    }
+
+    private function createExceptionFromResponse(HttpResponse $response): GlobalPostClientException
+    {
+        $body = $response->getBody();
+        $headers = $response->getHeaders();
+        $status = $response->getStatusCode();
+        $message = 'GlobalPost API request failed with status ' . $status . '.';
+        $errorCode = null;
+
+        $contentType = $response->getHeaderLine('Content-Type');
+        if (is_string($contentType) && strpos($contentType, 'application/json') !== false) {
+            $decoded = json_decode($body, true);
+            if (is_array($decoded)) {
+                if (isset($decoded['message']) && is_string($decoded['message'])) {
+                    $message = $decoded['message'];
+                } elseif (isset($decoded['error']) && is_string($decoded['error'])) {
+                    $message = $decoded['error'];
+                }
+
+                if (isset($decoded['code']) && is_scalar($decoded['code'])) {
+                    $errorCode = (string) $decoded['code'];
+                }
+            }
+        }
+
+        return new GlobalPostClientException($message, $status, $errorCode, $body, $headers);
+    }
+
+    /**
+     * @param array<string, scalar|array<scalar>> $params
+     */
+    private function buildQuery(array $params): string
+    {
+        $normalized = [];
+        foreach ($params as $key => $value) {
+            if (is_array($value)) {
+                $normalized[$key] = $this->sanitizeArray($value);
+            } elseif (is_scalar($value) || $value === null) {
+                $normalized[$key] = $value;
+            }
+        }
+
+        return http_build_query($normalized, '', '&', PHP_QUERY_RFC3986);
+    }
+
+    /**
+     * @param array<int|string, mixed> $value
+     *
+     * @return array<int|string, scalar|null|array<scalar|null>>
+     */
+    private function sanitizeArray(array $value): array
+    {
+        $sanitized = [];
+        foreach ($value as $key => $item) {
+            if (is_array($item)) {
+                $sanitized[$key] = $this->sanitizeArray($item);
+            } elseif (is_scalar($item) || $item === null) {
+                $sanitized[$key] = $item;
+            }
+        }
+
+        return $sanitized;
+    }
+
+    private function decodeJson(HttpResponse $response): array
+    {
+        $body = $response->getBody();
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded)) {
+            throw new GlobalPostClientException(
+                'Failed to decode GlobalPost API response.',
+                $response->getStatusCode(),
+                null,
+                $body,
+                $response->getHeaders()
+            );
+        }
+
+        return $decoded;
+    }
+
+    private function logDebug(string $message, array $context = []): void
+    {
+        if ($this->debug) {
+            $this->logger->debug($message, $this->maskContext($context));
+        }
+    }
+
+    private function logWarning(string $message, array $context = []): void
+    {
+        $this->logger->warning($message, $this->maskContext($context));
+    }
+
+    private function maskContext(array $context): array
+    {
+        $masked = [];
+        foreach ($context as $key => $value) {
+            if (is_scalar($value) || $value === null) {
+                $masked[$key] = $value;
+                continue;
+            }
+
+            if (is_array($value)) {
+                $masked[$key] = array_map(static function ($item) {
+                    if (is_scalar($item) || $item === null) {
+                        return $item;
+                    }
+
+                    return '[filtered]';
+                }, $value);
+                continue;
+            }
+
+            $masked[$key] = '[filtered]';
+        }
+
+        return $masked;
+    }
+}

--- a/modules/globalpostshipping/src/SDK/GlobalPostClientException.php
+++ b/modules/globalpostshipping/src/SDK/GlobalPostClientException.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace GlobalPostShipping\SDK;
+
+use RuntimeException;
+use Throwable;
+
+class GlobalPostClientException extends RuntimeException
+{
+    private ?int $statusCode;
+
+    private ?string $errorCode;
+
+    private ?string $responseBody;
+
+    /**
+     * @var array<string, array<int, string>>|null
+     */
+    private ?array $responseHeaders;
+
+    /**
+     * @param array<string, array<int, string>>|null $responseHeaders
+     */
+    public function __construct(
+        string $message,
+        ?int $statusCode = null,
+        ?string $errorCode = null,
+        ?string $responseBody = null,
+        ?array $responseHeaders = null,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $statusCode ?? 0, $previous);
+        $this->statusCode = $statusCode;
+        $this->errorCode = $errorCode;
+        $this->responseBody = $responseBody;
+        $this->responseHeaders = $responseHeaders;
+    }
+
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
+    }
+
+    public function getErrorCode(): ?string
+    {
+        return $this->errorCode;
+    }
+
+    public function getResponseBody(): ?string
+    {
+        return $this->responseBody;
+    }
+
+    /**
+     * @return array<string, array<int, string>>|null
+     */
+    public function getResponseHeaders(): ?array
+    {
+        return $this->responseHeaders;
+    }
+}

--- a/modules/globalpostshipping/src/SDK/HttpResponse.php
+++ b/modules/globalpostshipping/src/SDK/HttpResponse.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace GlobalPostShipping\SDK;
+
+class HttpResponse
+{
+    private int $statusCode;
+
+    /**
+     * @var array<string, array<int, string>>
+     */
+    private array $headers;
+
+    private string $body;
+
+    /**
+     * @param array<string, array<int, string>> $headers
+     */
+    public function __construct(int $statusCode, array $headers, string $body)
+    {
+        $this->statusCode = $statusCode;
+        $this->headers = $headers;
+        $this->body = $body;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    public function getHeaderLine(string $header): ?string
+    {
+        $normalized = strtolower($header);
+        if (!isset($this->headers[$normalized])) {
+            return null;
+        }
+
+        return implode(', ', $this->headers[$normalized]);
+    }
+}

--- a/modules/globalpostshipping/src/SDK/HttpTransportException.php
+++ b/modules/globalpostshipping/src/SDK/HttpTransportException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GlobalPostShipping\SDK;
+
+use RuntimeException;
+use Throwable;
+
+class HttpTransportException extends RuntimeException
+{
+    private ?HttpResponse $response;
+
+    public function __construct(string $message, int $code = 0, ?HttpResponse $response = null, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->response = $response;
+    }
+
+    public function getResponse(): ?HttpResponse
+    {
+        return $this->response;
+    }
+}

--- a/modules/globalpostshipping/src/SDK/HttpTransportInterface.php
+++ b/modules/globalpostshipping/src/SDK/HttpTransportInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GlobalPostShipping\SDK;
+
+interface HttpTransportInterface
+{
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed> $options
+     *
+     * @throws HttpTransportException
+     */
+    public function request(string $method, string $url, array $headers = [], array $options = []): HttpResponse;
+}

--- a/modules/globalpostshipping/src/SDK/LoggerInterface.php
+++ b/modules/globalpostshipping/src/SDK/LoggerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GlobalPostShipping\SDK;
+
+interface LoggerInterface
+{
+    public function emergency(string $message, array $context = []): void;
+
+    public function alert(string $message, array $context = []): void;
+
+    public function critical(string $message, array $context = []): void;
+
+    public function error(string $message, array $context = []): void;
+
+    public function warning(string $message, array $context = []): void;
+
+    public function notice(string $message, array $context = []): void;
+
+    public function info(string $message, array $context = []): void;
+
+    public function debug(string $message, array $context = []): void;
+
+    public function log(string $level, string $message, array $context = []): void;
+}

--- a/modules/globalpostshipping/src/SDK/NullLogger.php
+++ b/modules/globalpostshipping/src/SDK/NullLogger.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace GlobalPostShipping\SDK;
+
+class NullLogger implements LoggerInterface
+{
+    public function emergency(string $message, array $context = []): void
+    {
+    }
+
+    public function alert(string $message, array $context = []): void
+    {
+    }
+
+    public function critical(string $message, array $context = []): void
+    {
+    }
+
+    public function error(string $message, array $context = []): void
+    {
+    }
+
+    public function warning(string $message, array $context = []): void
+    {
+    }
+
+    public function notice(string $message, array $context = []): void
+    {
+    }
+
+    public function info(string $message, array $context = []): void
+    {
+    }
+
+    public function debug(string $message, array $context = []): void
+    {
+    }
+
+    public function log(string $level, string $message, array $context = []): void
+    {
+    }
+}

--- a/tests/SDK/GlobalPostClientTest.php
+++ b/tests/SDK/GlobalPostClientTest.php
@@ -1,0 +1,242 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+use GlobalPostShipping\SDK\GlobalPostClient;
+use GlobalPostShipping\SDK\GlobalPostClientException;
+use GlobalPostShipping\SDK\HttpResponse;
+use GlobalPostShipping\SDK\HttpTransportException;
+use GlobalPostShipping\SDK\HttpTransportInterface;
+use GlobalPostShipping\SDK\LoggerInterface;
+
+/**
+ * @param mixed $expected
+ * @param mixed $actual
+ * @param string $message
+ */
+function assertSame($expected, $actual, string $message = ''): void
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException($message !== '' ? $message : 'Failed asserting that values are identical.');
+    }
+}
+
+/**
+ * @param callable $test
+ */
+function runTest(string $name, callable $test): void
+{
+    try {
+        $test();
+        echo '.';
+    } catch (Throwable $exception) {
+        echo PHP_EOL . 'Test failed: ' . $name . PHP_EOL;
+        echo $exception->getMessage() . PHP_EOL;
+        exit(1);
+    }
+}
+
+class MockTransport implements HttpTransportInterface
+{
+    /**
+     * @var array<int, array{method: string, url: string, headers: array<string, string>, body: ?string}>
+     */
+    public array $requests = [];
+
+    /**
+     * @var array<int, HttpResponse|HttpTransportException>
+     */
+    private array $queue;
+
+    public function __construct(HttpResponse ...$responses)
+    {
+        $this->queue = $responses;
+    }
+
+    public function push(HttpResponse $response): void
+    {
+        $this->queue[] = $response;
+    }
+
+    public function pushException(HttpTransportException $exception): void
+    {
+        $this->queue[] = $exception;
+    }
+
+    public function request(string $method, string $url, array $headers = [], array $options = []): HttpResponse
+    {
+        $body = null;
+        if (array_key_exists('body', $options)) {
+            $body = $options['body'];
+        }
+
+        $normalizedHeaders = [];
+        foreach ($headers as $name => $value) {
+            $normalizedHeaders[$name] = $value;
+        }
+
+        $this->requests[] = [
+            'method' => strtoupper($method),
+            'url' => $url,
+            'headers' => $normalizedHeaders,
+            'body' => $body,
+        ];
+
+        if (count($this->queue) === 0) {
+            throw new RuntimeException('Mock transport queue exhausted.');
+        }
+
+        $response = array_shift($this->queue);
+        if ($response instanceof HttpTransportException) {
+            throw $response;
+        }
+
+        return $response;
+    }
+}
+
+class MemoryLogger implements LoggerInterface
+{
+    public array $messages = [];
+
+    public function emergency(string $message, array $context = []): void
+    {
+        $this->log('emergency', $message, $context);
+    }
+
+    public function alert(string $message, array $context = []): void
+    {
+        $this->log('alert', $message, $context);
+    }
+
+    public function critical(string $message, array $context = []): void
+    {
+        $this->log('critical', $message, $context);
+    }
+
+    public function error(string $message, array $context = []): void
+    {
+        $this->log('error', $message, $context);
+    }
+
+    public function warning(string $message, array $context = []): void
+    {
+        $this->log('warning', $message, $context);
+    }
+
+    public function notice(string $message, array $context = []): void
+    {
+        $this->log('notice', $message, $context);
+    }
+
+    public function info(string $message, array $context = []): void
+    {
+        $this->log('info', $message, $context);
+    }
+
+    public function debug(string $message, array $context = []): void
+    {
+        $this->log('debug', $message, $context);
+    }
+
+    public function log(string $level, string $message, array $context = []): void
+    {
+        $this->messages[] = [$level, $message, $context];
+    }
+}
+
+runTest('it builds countries request', function (): void {
+    $transport = new MockTransport(new HttpResponse(200, ['content-type' => ['application/json']], json_encode(['UA', 'US'], JSON_THROW_ON_ERROR)));
+    $logger = new MemoryLogger();
+
+    $client = new GlobalPostClient('token', GlobalPostClient::MODE_TEST, ['debug' => true], $transport, $logger);
+    $countries = $client->getCountries();
+
+    assertSame(['UA', 'US'], $countries, 'Countries response should be decoded.');
+
+    $request = $transport->requests[0];
+    assertSame('GET', $request['method'], 'Method should be GET.');
+    assertSame('https://test-api.globalpost.com.ua/public/tariff-international/countries', $request['url'], 'URL should match base URL.');
+    assertSame('Bearer token', $request['headers']['Authorization'] ?? null, 'Authorization header missing.');
+    assertSame('application/json', $request['headers']['Accept'] ?? null, 'Default Accept header should be JSON.');
+    assertSame(null, $request['body'], 'GET request should not send body.');
+    assertSame('debug', $logger->messages[0][0] ?? null, 'Debug log should be recorded when debug enabled.');
+});
+
+runTest('it builds tariff options query string', function (): void {
+    $responseBody = json_encode(['options' => [['id' => 1]]], JSON_THROW_ON_ERROR);
+    $transport = new MockTransport(new HttpResponse(200, ['content-type' => ['application/json']], $responseBody));
+
+    $client = new GlobalPostClient('abc', GlobalPostClient::MODE_TEST, [], $transport, new MemoryLogger());
+    $result = $client->getOptions([
+        'from_country' => 'UA',
+        'to_country' => 'US',
+        'weight' => 1200,
+    ]);
+
+    assertSame(['options' => [['id' => 1]]], $result, 'Options response should be decoded.');
+
+    $request = $transport->requests[0];
+    assertSame('https://test-api.globalpost.com.ua/public/tariff-international/get-options?from_country=UA&to_country=US&weight=1200', $request['url'], 'Query string should be appended.');
+});
+
+runTest('it encodes form data when creating short order', function (): void {
+    $transport = new MockTransport(new HttpResponse(200, ['content-type' => ['application/json']], json_encode(['order' => '123'], JSON_THROW_ON_ERROR)));
+
+    $client = new GlobalPostClient('t', GlobalPostClient::MODE_PROD, [], $transport, new MemoryLogger());
+    $result = $client->createShortOrder([
+        'recipient_name' => 'John',
+        'recipient_phone' => '+380001112233',
+    ]);
+
+    assertSame(['order' => '123'], $result, 'Order response should be decoded.');
+
+    $request = $transport->requests[0];
+    assertSame('https://api.globalpost.com.ua/api/create-short-order', $request['url'], 'Production base URL should be used.');
+    assertSame('recipient_name=John&recipient_phone=%2B380001112233', $request['body'], 'Form data should be URL encoded.');
+    assertSame('application/x-www-form-urlencoded', $request['headers']['Content-Type'] ?? null, 'Content-Type should be set.');
+});
+
+runTest('it retries on server error', function (): void {
+    $transport = new MockTransport(
+        new HttpResponse(500, ['content-type' => ['application/json']], json_encode(['message' => 'Server error'], JSON_THROW_ON_ERROR)),
+        new HttpResponse(200, ['content-type' => ['application/json']], json_encode(['ok' => true], JSON_THROW_ON_ERROR))
+    );
+
+    $client = new GlobalPostClient('token', GlobalPostClient::MODE_TEST, ['max_retries' => 2, 'retry_delay' => 0.0], $transport, new MemoryLogger());
+    $result = $client->getCountries();
+
+    assertSame(['ok' => true], $result, 'Client should retry and succeed.');
+    assertSame(2, count($transport->requests), 'Client should perform two attempts.');
+});
+
+runTest('it throws informative exception on client error', function (): void {
+    $body = json_encode(['message' => 'Invalid data', 'code' => 'invalid_data'], JSON_THROW_ON_ERROR);
+    $transport = new MockTransport(new HttpResponse(400, ['content-type' => ['application/json']], $body));
+
+    $client = new GlobalPostClient('token', GlobalPostClient::MODE_TEST, [], $transport, new MemoryLogger());
+
+    try {
+        $client->createShortOrder(['foo' => 'bar']);
+    } catch (GlobalPostClientException $exception) {
+        assertSame(400, $exception->getStatusCode(), 'Status code should be exposed.');
+        assertSame('invalid_data', $exception->getErrorCode(), 'Error code should be exposed.');
+        assertSame('Invalid data', $exception->getMessage(), 'Message should be derived from response.');
+        return;
+    }
+
+    throw new RuntimeException('Expected GlobalPostClientException was not thrown.');
+});
+
+runTest('it returns binary bodies for documents', function (): void {
+    $transport = new MockTransport(new HttpResponse(200, ['content-type' => ['application/pdf']], '%PDF-1.4 label'));
+
+    $client = new GlobalPostClient('token', GlobalPostClient::MODE_TEST, [], $transport, new MemoryLogger());
+    $pdf = $client->printLabel('uk', 'ORDER-1');
+
+    assertSame('%PDF-1.4 label', $pdf, 'Binary response should be returned as-is.');
+    $request = $transport->requests[0];
+    assertSame('application/pdf', $request['headers']['Accept'] ?? null, 'Accept header should request PDF.');
+});
+
+echo PHP_EOL . 'All tests passed' . PHP_EOL;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'GlobalPostShipping\\';
+    $baseDir = __DIR__ . '/../modules/globalpostshipping/src/';
+
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+
+    $relativeClass = substr($class, strlen($prefix));
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (is_file($file)) {
+        require_once $file;
+    }
+});


### PR DESCRIPTION
## Summary
- implement an SDK-level GlobalPostClient that handles bearer auth, mode-aware base URLs, retries, error parsing and logging
- provide cURL transport, response/exception helpers, and a null logger to support the client
- add unit tests for the client plus an executable usage example script

## Testing
- php tests/SDK/GlobalPostClientTest.php

------
https://chatgpt.com/codex/tasks/task_b_68cc11feb89083239fe3a300b3862531