### PR TITLE
Implement GlobalPost carrier registration and checkout tariffs

### DIFF
--- a/modules/globalpostshipping/src/Installer/DatabaseInstaller.php
+++ b/modules/globalpostshipping/src/Installer/DatabaseInstaller.php
@@ -52,7 +52,8 @@ class DatabaseInstaller
                 `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                 PRIMARY KEY (`id_globalpost_order`),
-                UNIQUE KEY `idx_globalpost_order_shipment` (`shipment_id`)
+                UNIQUE KEY `idx_globalpost_order_shipment` (`shipment_id`),
+                UNIQUE KEY `idx_globalpost_order_cart_type` (`id_cart`, `type`)
             ) ENGINE=%2$s DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
             $this->getTableName(),
             \pSQL($this->engine)

--- a/modules/globalpostshipping/views/templates/hook/carrier_options.tpl
+++ b/modules/globalpostshipping/views/templates/hook/carrier_options.tpl
@@ -1,0 +1,21 @@
+{if isset($globalpost_options) && $globalpost_options}
+<div class="globalpost-carrier-options" data-globalpost-type="{$globalpost_type|escape:'html':'UTF-8'}">
+  <p class="globalpost-title">{$globalpost_title|escape:'html':'UTF-8'}</p>
+  <ul class="globalpost-options-list">
+    {foreach from=$globalpost_options item=option name=options}
+      <li class="globalpost-option-item">
+        <label class="globalpost-option-label">
+          <input type="radio"
+                 name="globalpost_option[{$globalpost_type|escape:'html':'UTF-8'}]"
+                 value="{$option.key|escape:'html':'UTF-8'}"
+                 {if $globalpost_selected_key == $option.key || (!$globalpost_selected_key && $smarty.foreach.options.first)}checked="checked"{/if}>
+          <span>{$option.label|escape:'html':'UTF-8'}</span>
+        </label>
+        {if $option.estimate}
+          <div class="globalpost-option-estimate">{$option.estimate|escape:'html':'UTF-8'}</div>
+        {/if}
+      </li>
+    {/foreach}
+  </ul>
+</div>
+{/if}


### PR DESCRIPTION
## Summary
- register GlobalPost carriers during installation and retire them on uninstall
- request, cache, and persist GlobalPost tariff selections across checkout hooks
- add a Smarty template to present tariff choices and ensure unique cart/type rows

## Testing
- php -l modules/globalpostshipping/globalpostshipping.php
- php -l modules/globalpostshipping/src/Installer/DatabaseInstaller.php
- phpunit --bootstrap tests/bootstrap.php --testdox tests *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68cc15dd886083238f66ad1b9a3cb8f3