### PR TITLE
Implement cart data mapping improvements

### DIFF
--- a/modules/globalpostshipping/src/Tariff/CartMeasurementCalculator.php
+++ b/modules/globalpostshipping/src/Tariff/CartMeasurementCalculator.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace GlobalPostShipping\Tariff;
+
+class CartMeasurementCalculator
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $products;
+
+    /**
+     * @param array<int, array<string, mixed>> $products
+     */
+    public function __construct(array $products)
+    {
+        $this->products = $products;
+    }
+
+    public function calculateTotalWeight(): float
+    {
+        $totalWeight = 0.0;
+
+        foreach ($this->products as $product) {
+            $quantity = $this->extractQuantity($product);
+            if ($quantity <= 0) {
+                continue;
+            }
+
+            $weight = $this->extractFloat($product, ['weight']);
+            if ($weight <= 0.0) {
+                continue;
+            }
+
+            $totalWeight += $weight * $quantity;
+        }
+
+        return $totalWeight;
+    }
+
+    /**
+     * @return array{length?: float, width?: float, height?: float}
+     */
+    public function calculateDimensions(): array
+    {
+        $dimensions = [];
+
+        $length = $this->calculateMaxDimension(['length', 'depth']);
+        if ($length !== null && $length > 0.0) {
+            $dimensions['length'] = $length;
+        }
+
+        $width = $this->calculateMaxDimension(['width']);
+        if ($width !== null && $width > 0.0) {
+            $dimensions['width'] = $width;
+        }
+
+        $height = $this->calculateStackedHeight();
+        if ($height !== null && $height > 0.0) {
+            $dimensions['height'] = $height;
+        }
+
+        return $dimensions;
+    }
+
+    private function calculateMaxDimension(array $keys): ?float
+    {
+        $max = null;
+
+        foreach ($this->products as $product) {
+            $quantity = $this->extractQuantity($product);
+            if ($quantity <= 0) {
+                continue;
+            }
+
+            $value = $this->extractFloat($product, $keys);
+            if ($value <= 0.0) {
+                continue;
+            }
+
+            if ($max === null || $value > $max) {
+                $max = $value;
+            }
+        }
+
+        return $max;
+    }
+
+    private function calculateStackedHeight(): ?float
+    {
+        $total = 0.0;
+        $hasHeight = false;
+
+        foreach ($this->products as $product) {
+            $quantity = $this->extractQuantity($product);
+            if ($quantity <= 0) {
+                continue;
+            }
+
+            $height = $this->extractFloat($product, ['height']);
+            if ($height <= 0.0) {
+                continue;
+            }
+
+            $total += $height * $quantity;
+            $hasHeight = true;
+        }
+
+        return $hasHeight ? $total : null;
+    }
+
+    private function extractQuantity(array $product): int
+    {
+        if (isset($product['cart_quantity'])) {
+            return (int) $product['cart_quantity'];
+        }
+
+        if (isset($product['quantity'])) {
+            return (int) $product['quantity'];
+        }
+
+        return 0;
+    }
+
+    private function extractFloat(array $product, array $keys): float
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $product)) {
+                continue;
+            }
+
+            $value = (float) $product[$key];
+            if (!is_finite($value)) {
+                continue;
+            }
+
+            return $value;
+        }
+
+        return 0.0;
+    }
+}

--- a/tests/Module/CartMeasurementCalculatorTest.php
+++ b/tests/Module/CartMeasurementCalculatorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+use GlobalPostShipping\Tariff\CartMeasurementCalculator;
+
+/**
+ * @param float $expected
+ * @param float $actual
+ * @param float $delta
+ * @param string $message
+ */
+function assertFloatEquals($expected, $actual, $delta, string $message = ''): void
+{
+    if (abs($expected - $actual) > $delta) {
+        throw new RuntimeException($message !== '' ? $message : sprintf('Failed asserting that %.4f matches %.4f', $expected, $actual));
+    }
+}
+
+/**
+ * @param mixed $expected
+ * @param mixed $actual
+ * @param string $message
+ */
+function assertSameValue($expected, $actual, string $message = ''): void
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException($message !== '' ? $message : 'Failed asserting that values are identical.');
+    }
+}
+
+/**
+ * @param callable $test
+ */
+function runTest(string $name, callable $test): void
+{
+    try {
+        $test();
+        echo '.';
+    } catch (Throwable $exception) {
+        echo PHP_EOL . 'Test failed: ' . $name . PHP_EOL;
+        echo $exception->getMessage() . PHP_EOL;
+        exit(1);
+    }
+}
+
+runTest('it sums cart weight and dimensions from products', function (): void {
+    $calculator = new CartMeasurementCalculator([
+        [
+            'cart_quantity' => 2,
+            'weight' => 0.75,
+            'depth' => 25.4,
+            'width' => 15.2,
+            'height' => 4.5,
+        ],
+        [
+            'cart_quantity' => 1,
+            'weight' => 1.2,
+            'depth' => 32.0,
+            'width' => 12.0,
+            'height' => 8.0,
+        ],
+    ]);
+
+    assertFloatEquals(2.7, $calculator->calculateTotalWeight(), 0.0001, 'Weight should sum quantity and product weight.');
+
+    $dimensions = $calculator->calculateDimensions();
+    assertFloatEquals(32.0, $dimensions['length'] ?? 0.0, 0.0001, 'Length should be the largest product depth.');
+    assertFloatEquals(15.2, $dimensions['width'] ?? 0.0, 0.0001, 'Width should be the largest product width.');
+    assertFloatEquals(17.0, $dimensions['height'] ?? 0.0, 0.0001, 'Height should stack product heights by quantity.');
+});
+
+runTest('it ignores invalid measurements and quantities', function (): void {
+    $calculator = new CartMeasurementCalculator([
+        [
+            'cart_quantity' => 0,
+            'weight' => 10,
+            'depth' => 10,
+            'width' => 10,
+            'height' => 10,
+        ],
+        [
+            'cart_quantity' => 1,
+            'weight' => -5,
+            'depth' => null,
+            'width' => '0',
+            'height' => '0',
+        ],
+    ]);
+
+    assertFloatEquals(0.0, $calculator->calculateTotalWeight(), 0.0001, 'Invalid weight rows should be ignored.');
+
+    $dimensions = $calculator->calculateDimensions();
+    assertSameValue([], $dimensions, 'Invalid dimensions should not be included.');
+});
+
+runTest('it falls back to quantity key when cart_quantity missing', function (): void {
+    $calculator = new CartMeasurementCalculator([
+        [
+            'quantity' => 3,
+            'weight' => 0.2,
+            'length' => 18,
+            'width' => 6,
+            'height' => 3.5,
+        ],
+    ]);
+
+    assertFloatEquals(0.6, $calculator->calculateTotalWeight(), 0.0001, 'Quantity should fallback to the quantity key.');
+
+    $dimensions = $calculator->calculateDimensions();
+    assertFloatEquals(18.0, $dimensions['length'] ?? 0.0, 0.0001, 'Length should use the first available key.');
+    assertFloatEquals(6.0, $dimensions['width'] ?? 0.0, 0.0001, 'Width should be extracted when available.');
+    assertFloatEquals(10.5, $dimensions['height'] ?? 0.0, 0.0001, 'Height should stack using the quantity.');
+});
+


### PR DESCRIPTION
## Summary
- add a cart measurement calculator to aggregate weights and parcel dimensions from products
- integrate the calculator into tariff context building with insurance rule handling and configurable shipment mode
- expose shipment type mode and insurance rule options in the module settings and cover the calculator with tests

## Testing
- php tests/SDK/GlobalPostClientTest.php
- php tests/Module/CartMeasurementCalculatorTest.php

------
https://chatgpt.com/codex/tasks/task_b_68cc2299c3f88323b9cac94fb394c9d0