### PR TITLE
Persist tariff selection and move to order

### DIFF
--- a/modules/globalpostshipping/src/Installer/DatabaseInstaller.php
+++ b/modules/globalpostshipping/src/Installer/DatabaseInstaller.php
@@ -36,7 +36,7 @@ class DatabaseInstaller
         $sql = sprintf(
             'CREATE TABLE IF NOT EXISTS `%1$s` (
                 `id_globalpost_order` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-                `id_cart` INT UNSIGNED NOT NULL,
+                `id_cart` INT UNSIGNED DEFAULT NULL,
                 `id_order` INT UNSIGNED DEFAULT NULL,
                 `country_from` VARCHAR(2) NOT NULL,
                 `country_to` VARCHAR(2) NOT NULL,


### PR DESCRIPTION
## Summary
- allow globalpost order records to persist tariff details and clear cart linkage when an order is validated
- make sure the database schema supports null cart IDs and adjusts existing tables on demand

## Testing
- php -l modules/globalpostshipping/globalpostshipping.php
- php -l modules/globalpostshipping/src/Installer/DatabaseInstaller.php

------
https://chatgpt.com/codex/tasks/task_b_68cc3b665454832394d440b8881e7e9a