### PR TITLE
feat: auto-create GlobalPost shipments after order validation

### DIFF
--- a/docs/logs/sample_auto_shipment_log.json
+++ b/docs/logs/sample_auto_shipment_log.json
@@ -1,0 +1,94 @@
+{
+    "shipment_logs": [
+        {
+            "status": "success",
+            "timestamp": "2024-03-18T10:42:11+00:00",
+            "request": {
+                "lang": "en",
+                "number_auto": 1,
+                "order_id": "ABCD1234",
+                "is_international": 1,
+                "weight_type": 1024,
+                "weight": 1.25,
+                "places": 1,
+                "about": "Order #ABCD1234",
+                "contragent_key": "TARIFF-KEY-001",
+                "international_tariff_id": 42,
+                "price": 899.5,
+                "insured": 1,
+                "insured_amount": 899.5,
+                "sender_name": "GlobalPost Shop",
+                "sender_phone": "********56",
+                "sender_email": "s***@example.com",
+                "sender_country": "UA",
+                "sender_city": "Kyiv",
+                "sender_address": "1 Volodymyrska St",
+                "sender_zip": "01001",
+                "sender_state": "KV",
+                "recipient_name": "John Doe",
+                "recipient_phone": "********89",
+                "recipient_email": "j***@customer.com",
+                "recipient_country": "US",
+                "recipient_city": "New York",
+                "recipient_address": "350 Fifth Avenue",
+                "recipient_zip": "10001",
+                "recipient_state": "NY",
+                "length": 30.0,
+                "width": 20.0,
+                "height": 15.0,
+                "purpose_parcel": "sale",
+                "incoterms": "DAP",
+                "currency_invoice": "USD",
+                "name_item": [
+                    "T-Shirt",
+                    "Coffee Mug"
+                ],
+                "count_items": [
+                    2,
+                    1
+                ],
+                "unit": [
+                    "pcs",
+                    "pcs"
+                ],
+                "price_unit": [
+                    25.0,
+                    15.0
+                ],
+                "weight_unit": [
+                    0.35,
+                    0.15
+                ],
+                "made_country": [
+                    "UA",
+                    "UA"
+                ],
+                "sum_invoice": 65.0,
+                "sum_weight": 0.85
+            },
+            "response": {
+                "id": "SH123456789",
+                "number": "GP000000001",
+                "status": "created"
+            },
+            "meta": {
+                "shipment_id": "SH123456789",
+                "ttn": "GP000000001"
+            }
+        },
+        {
+            "status": "failed",
+            "timestamp": "2024-03-18T10:15:00+00:00",
+            "request": {
+                "lang": "en",
+                "order_id": "ABCD1234",
+                "contragent_key": "TARIFF-KEY-001"
+            },
+            "response": {
+                "error": "validation_error",
+                "message": "Weight must be greater than zero"
+            },
+            "message": "GlobalPost shipment creation failed: Weight must be greater than zero"
+        }
+    ]
+}

--- a/modules/globalpostshipping/README.md
+++ b/modules/globalpostshipping/README.md
@@ -26,7 +26,13 @@ The database table created by the module is dropped during uninstallation.
 
 ## Configuration
 
-The current version of the module does not expose any configuration options. Future iterations will introduce settings for API credentials and shipment preferences.
+After installing the module open the GlobalPost configuration page in the back office and provide the required API credentials. The form allows you to define sender contact details, enable or disable automatic shipment creation, configure default parcel dimensions, customs declaration defaults, and the tracking URL template.
+
+### Automatic shipment creation
+
+When the option **Auto-create shipment after order confirmation** is enabled the module will automatically call the GlobalPost `POST /api/create-short-order` endpoint once an order that uses a GlobalPost carrier is validated. The generated shipment identifier and TTN are saved inside the `ps_globalpost_order` table and applied as the order tracking number. Each API request and response is logged in a sanitized JSON payload stored alongside the order record for troubleshooting.
+
+An example of the stored log structure is available in [`docs/logs/sample_auto_shipment_log.json`](../../docs/logs/sample_auto_shipment_log.json).
 
 ## Development
 


### PR DESCRIPTION
## Summary
- hook into order validation to call GlobalPost create-short-order when auto-create is enabled
- compose the shipment payload including sender/recipient, parcel/customs, insurance, and tariff data
- persist shipment id and TTN, update tracking number, and log sanitized request/response metadata
- document the new workflow and provide a sample log plus UI screenshot artifact

## Testing
- not run (module requires PrestaShop runtime)


------
https://chatgpt.com/codex/tasks/task_b_68cc40a801588323908193c21c39f99e