### PR TITLE
Add customer tracking link in order history and emails

### DIFF
--- a/modules/globalpostshipping/views/templates/hook/order_tracking.tpl
+++ b/modules/globalpostshipping/views/templates/hook/order_tracking.tpl
@@ -1,0 +1,18 @@
+{if isset($globalpost_tracking) && $globalpost_tracking.number}
+<div class="card mt-3" id="globalpost-tracking-block">
+  <div class="card-header">
+    <h3 class="card-title mb-0">{$globalpost_tracking.title|escape:'html':'UTF-8'}</h3>
+  </div>
+  <div class="card-body">
+    <p class="mb-2">
+      <strong>{$globalpost_tracking.label_number|escape:'html':'UTF-8'}:</strong>
+      <span class="ml-1">{$globalpost_tracking.number|escape:'html':'UTF-8'}</span>
+    </p>
+    {if $globalpost_tracking.url}
+      <a class="btn btn-outline-primary" href="{$globalpost_tracking.url|escape:'html':'UTF-8'}" target="_blank" rel="noopener">
+        {$globalpost_tracking.label_link|escape:'html':'UTF-8'}
+      </a>
+    {/if}
+  </div>
+</div>
+{/if}


### PR DESCRIPTION
## Summary
- display the GlobalPost tracking number and link in the customer order detail view
- keep the order shipping number and carrier tracking number synchronized with saved TTNs
- expose tracking placeholders so the shipped email includes the follow-up link when using the standard template

## Testing
- php -l modules/globalpostshipping/globalpostshipping.php

------
https://chatgpt.com/codex/tasks/task_b_68cd20a9c79483239ecba0872368a941