### PR TITLE
Improve GlobalPost error handling and logging

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,38 @@
+# GlobalPost error handling
+
+The module normalises responses from the GlobalPost API before surfacing them to administrators. Failures are mapped to human-readable error codes and messages, while the storefront hides GlobalPost carriers whenever tariff calculation or shipment creation fails.
+
+## Error code mapping
+
+The table below summarises the API status codes and explicit error identifiers that are recognised by the module. The mapping is implemented in `GlobalPostShipping\Error\ErrorMapper`.
+
+| HTTP status | Admin code                | Description                                                |
+|-------------|---------------------------|------------------------------------------------------------|
+| 400         | `api_bad_request`         | Request rejected by GlobalPost as invalid.                 |
+| 401         | `api_auth_failed`         | Authentication failed, token must be updated.              |
+| 403         | `api_forbidden`           | API access denied for the current credentials.             |
+| 404         | `api_not_found`           | Requested shipment or document is missing.                 |
+| 409         | `api_conflict`            | Duplicate shipment detected on GlobalPost.                 |
+| 422         | `api_validation_failed`   | Payload validation failed on the GlobalPost side.          |
+| 429         | `api_rate_limited`        | Too many requests sent to GlobalPost.                      |
+| 5xx         | `api_service_unavailable` | GlobalPost service temporarily unavailable.                |
+
+| API error code      | Admin code                |
+|---------------------|---------------------------|
+| `INVALID_TOKEN`     | `api_auth_failed`         |
+| `AUTH_ERROR`        | `api_auth_failed`         |
+| `PERMISSION_DENIED` | `api_forbidden`           |
+| `NOT_FOUND`         | `api_not_found`           |
+| `VALIDATION_ERROR`  | `api_validation_failed`   |
+| `RATE_LIMITED`      | `api_rate_limited`        |
+| `SERVER_ERROR`      | `api_service_unavailable` |
+
+Other transport failures (timeouts, DNS issues, TLS problems) are grouped under the `api_transport` code.
+
+## Debug logging
+
+Administrators can enable the **Enable debug logging** switch in the module settings to log sanitised request metadata and retry attempts to the PrestaShop log. Sensitive data (names, addresses, phone numbers, tokens) are automatically masked before logging. Disable the switch once troubleshooting is complete to avoid verbose logs.
+
+## Sample payload log
+
+See [`docs/logs/sample_auto_shipment_log.json`](logs/sample_auto_shipment_log.json) for a masked example of the stored request/response audit trail.

--- a/docs/logs/sample_auto_shipment_log.json
+++ b/docs/logs/sample_auto_shipment_log.json
@@ -17,21 +17,21 @@
                 "price": 899.5,
                 "insured": 1,
                 "insured_amount": 899.5,
-                "sender_name": "GlobalPost Shop",
+                "sender_name": "G***********p",
                 "sender_phone": "********56",
                 "sender_email": "s***@example.com",
                 "sender_country": "UA",
-                "sender_city": "Kyiv",
-                "sender_address": "1 Volodymyrska St",
-                "sender_zip": "01001",
+                "sender_city": "K**v",
+                "sender_address": "1**************t",
+                "sender_zip": "0***1",
                 "sender_state": "KV",
-                "recipient_name": "John Doe",
+                "recipient_name": "J*******e",
                 "recipient_phone": "********89",
                 "recipient_email": "j***@customer.com",
                 "recipient_country": "US",
-                "recipient_city": "New York",
-                "recipient_address": "350 Fifth Avenue",
-                "recipient_zip": "10001",
+                "recipient_city": "N*******k",
+                "recipient_address": "3***************e",
+                "recipient_zip": "1***1",
                 "recipient_state": "NY",
                 "length": 30.0,
                 "width": 20.0,
@@ -88,7 +88,15 @@
                 "error": "validation_error",
                 "message": "Weight must be greater than zero"
             },
-            "message": "GlobalPost shipment creation failed: Weight must be greater than zero"
+            "message": "GlobalPost validation failed for the shipment payload.",
+            "meta": {
+                "validation_errors": [
+                    {
+                        "field": "sender_phone",
+                        "error": "invalid_phone"
+                    }
+                ]
+            }
         }
     ]
 }

--- a/modules/globalpostshipping/README.md
+++ b/modules/globalpostshipping/README.md
@@ -34,6 +34,10 @@ When the option **Auto-create shipment after order confirmation** is enabled the
 
 An example of the stored log structure is available in [`docs/logs/sample_auto_shipment_log.json`](../../docs/logs/sample_auto_shipment_log.json).
 
+### Debug logging and troubleshooting
+
+Enable the **Enable debug logging** switch in the module settings when you need to troubleshoot API issues. Sanitised request metadata and retry attempts are written to the PrestaShop log without exposing personal data or credentials. Disable the switch once finished and consult [`docs/error-handling.md`](../../docs/error-handling.md) for the list of mapped error codes.
+
 ## Development
 
 Install Composer dependencies and enable PSR-4 autoloading with:

--- a/modules/globalpostshipping/controllers/admin/AdminGlobalPostShipmentsController.php
+++ b/modules/globalpostshipping/controllers/admin/AdminGlobalPostShipmentsController.php
@@ -66,7 +66,12 @@ class AdminGlobalPostShipmentsController extends ModuleAdminController
         }
 
         $code = isset($result['code']) ? (string) $result['code'] : 'creation_failed';
-        $this->redirectToOrder($orderId, ['globalpost_error' => $code]);
+        $params = ['globalpost_error' => $code];
+        if (!empty($result['message']) && is_string($result['message'])) {
+            $params['globalpost_error_message'] = strip_tags($result['message']);
+        }
+
+        $this->redirectToOrder($orderId, $params);
     }
 
     private function processDownloadDocument(string $type): void
@@ -93,7 +98,12 @@ class AdminGlobalPostShipmentsController extends ModuleAdminController
         $result = $this->module->fetchShipmentDocument($orderId, $type === 'invoice' ? 'invoice' : 'label');
         if (empty($result['success'])) {
             $code = isset($result['code']) ? (string) $result['code'] : 'api_error';
-            $this->redirectToOrder($orderId, ['globalpost_error' => $code]);
+            $params = ['globalpost_error' => $code];
+            if (!empty($result['message']) && is_string($result['message'])) {
+                $params['globalpost_error_message'] = strip_tags($result['message']);
+            }
+
+            $this->redirectToOrder($orderId, $params);
         }
 
         $filename = isset($result['filename']) ? (string) $result['filename'] : 'globalpost-document.pdf';

--- a/modules/globalpostshipping/src/Error/ErrorMapper.php
+++ b/modules/globalpostshipping/src/Error/ErrorMapper.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace GlobalPostShipping\Error;
+
+use GlobalPostShipping\SDK\GlobalPostClientException;
+use Throwable;
+
+class ErrorMapper
+{
+    private const STATUS_MAP = [
+        400 => ['code' => 'api_bad_request', 'message' => 'GlobalPost rejected the request as invalid.'],
+        401 => ['code' => 'api_auth_failed', 'message' => 'GlobalPost authentication failed. Check the API token.'],
+        403 => ['code' => 'api_forbidden', 'message' => 'GlobalPost denied access to the requested resource.'],
+        404 => ['code' => 'api_not_found', 'message' => 'GlobalPost could not find the requested resource.'],
+        409 => ['code' => 'api_conflict', 'message' => 'A conflicting shipment already exists in GlobalPost.'],
+        422 => ['code' => 'api_validation_failed', 'message' => 'GlobalPost validation failed for the shipment payload.'],
+        429 => ['code' => 'api_rate_limited', 'message' => 'Too many requests were sent to GlobalPost. Try again later.'],
+    ];
+
+    /**
+     * @var array<string, array{code: string, message: string}>
+     */
+    private const ERROR_CODE_MAP = [
+        'INVALID_TOKEN' => ['code' => 'api_auth_failed', 'message' => 'GlobalPost authentication failed. Check the API token.'],
+        'AUTH_ERROR' => ['code' => 'api_auth_failed', 'message' => 'GlobalPost authentication failed. Check the API token.'],
+        'PERMISSION_DENIED' => ['code' => 'api_forbidden', 'message' => 'GlobalPost denied access to the requested resource.'],
+        'NOT_FOUND' => ['code' => 'api_not_found', 'message' => 'GlobalPost could not find the requested resource.'],
+        'VALIDATION_ERROR' => ['code' => 'api_validation_failed', 'message' => 'GlobalPost validation failed for the shipment payload.'],
+        'RATE_LIMITED' => ['code' => 'api_rate_limited', 'message' => 'Too many requests were sent to GlobalPost. Try again later.'],
+        'SERVER_ERROR' => ['code' => 'api_service_unavailable', 'message' => 'GlobalPost service is temporarily unavailable. Try again later.'],
+    ];
+
+    /**
+     * Maps an API exception to a normalized error payload for the admin UI and logs.
+     *
+     * @return array{code: string, admin_message: string, log_message: string, status: int|null, api_code: string|null}
+     */
+    public static function fromClientException(GlobalPostClientException $exception): array
+    {
+        $status = $exception->getStatusCode();
+        $apiCodeRaw = $exception->getErrorCode();
+        $apiCode = $apiCodeRaw !== null ? strtoupper($apiCodeRaw) : null;
+        $message = trim($exception->getMessage());
+
+        $mapped = null;
+
+        if ($apiCode !== null && isset(self::ERROR_CODE_MAP[$apiCode])) {
+            $mapped = self::ERROR_CODE_MAP[$apiCode];
+        } elseif ($status !== null && isset(self::STATUS_MAP[$status])) {
+            $mapped = self::STATUS_MAP[$status];
+        } elseif ($status !== null && $status >= 500) {
+            $mapped = ['code' => 'api_service_unavailable', 'message' => 'GlobalPost service is temporarily unavailable. Try again later.'];
+        }
+
+        $code = $mapped['code'] ?? 'api_error';
+        $adminMessage = $mapped['message'] ?? 'GlobalPost returned an unexpected error. Try again later or contact support.';
+        $logMessage = $message !== '' ? $message : $adminMessage;
+
+        if ($status !== null) {
+            $logMessage = sprintf('HTTP %d: %s', $status, $logMessage);
+        }
+
+        if ($apiCode !== null) {
+            $logMessage .= sprintf(' [code: %s]', $apiCode);
+        }
+
+        return [
+            'code' => $code,
+            'admin_message' => $adminMessage,
+            'log_message' => $logMessage,
+            'status' => $status,
+            'api_code' => $apiCode,
+        ];
+    }
+
+    /**
+     * Maps a transport/network exception to a normalized error payload.
+     *
+     * @return array{code: string, admin_message: string, log_message: string}
+     */
+    public static function fromTransportException(Throwable $exception): array
+    {
+        $message = trim($exception->getMessage());
+        if ($message === '') {
+            $message = 'Network request to GlobalPost failed.';
+        }
+
+        return [
+            'code' => 'api_transport',
+            'admin_message' => 'Connection to GlobalPost failed. Check the network connection and retry.',
+            'log_message' => $message,
+        ];
+    }
+
+    /**
+     * Provides a combined list of handled HTTP and API codes for documentation purposes.
+     *
+     * @return array{status: int[], api: string[]}
+     */
+    public static function getHandledCodes(): array
+    {
+        return [
+            'status' => array_values(array_unique(array_merge(array_keys(self::STATUS_MAP), [500, 503]))),
+            'api' => array_values(array_unique(array_keys(self::ERROR_CODE_MAP))),
+        ];
+    }
+}

--- a/modules/globalpostshipping/src/Logger/PrestaShopLoggerAdapter.php
+++ b/modules/globalpostshipping/src/Logger/PrestaShopLoggerAdapter.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace GlobalPostShipping\Logger;
+
+use GlobalPostShipping\SDK\LoggerInterface;
+use PrestaShopLogger;
+use Tools;
+
+class PrestaShopLoggerAdapter implements LoggerInterface
+{
+    private const LEVEL_SEVERITY = [
+        'emergency' => 4,
+        'alert' => 4,
+        'critical' => 4,
+        'error' => 3,
+        'warning' => 2,
+        'notice' => 1,
+        'info' => 1,
+        'debug' => 1,
+    ];
+
+    private string $channel;
+
+    public function __construct(string $channel = 'globalpostshipping')
+    {
+        $this->channel = $channel;
+    }
+
+    public function emergency(string $message, array $context = []): void
+    {
+        $this->log('emergency', $message, $context);
+    }
+
+    public function alert(string $message, array $context = []): void
+    {
+        $this->log('alert', $message, $context);
+    }
+
+    public function critical(string $message, array $context = []): void
+    {
+        $this->log('critical', $message, $context);
+    }
+
+    public function error(string $message, array $context = []): void
+    {
+        $this->log('error', $message, $context);
+    }
+
+    public function warning(string $message, array $context = []): void
+    {
+        $this->log('warning', $message, $context);
+    }
+
+    public function notice(string $message, array $context = []): void
+    {
+        $this->log('notice', $message, $context);
+    }
+
+    public function info(string $message, array $context = []): void
+    {
+        $this->log('info', $message, $context);
+    }
+
+    public function debug(string $message, array $context = []): void
+    {
+        $this->log('debug', $message, $context);
+    }
+
+    public function log(string $level, string $message, array $context = []): void
+    {
+        $normalizedLevel = Tools::strtolower($level);
+        $severity = self::LEVEL_SEVERITY[$normalizedLevel] ?? 1;
+        $contextPayload = $this->encodeContext($context);
+        $logMessage = $message;
+
+        if ($contextPayload !== null) {
+            $logMessage .= ' | context: ' . $contextPayload;
+        }
+
+        PrestaShopLogger::addLog($logMessage, $severity, null, $this->channel, null, true);
+    }
+
+    private function encodeContext(array $context): ?string
+    {
+        if (empty($context)) {
+            return null;
+        }
+
+        $sanitized = $this->sanitizeContext($context);
+        $encoded = json_encode($sanitized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $encoded === false ? null : $encoded;
+    }
+
+    private function sanitizeContext(array $context): array
+    {
+        $result = [];
+
+        foreach ($context as $key => $value) {
+            if (is_array($value)) {
+                $result[$key] = $this->sanitizeContext($value);
+                continue;
+            }
+
+            if (is_scalar($value) || $value === null) {
+                $result[$key] = $this->sanitizeScalar($key, (string) ($value ?? ''));
+                continue;
+            }
+
+            $result[$key] = '[filtered]';
+        }
+
+        return $result;
+    }
+
+    private function sanitizeScalar(string $key, string $value): string
+    {
+        $normalizedKey = Tools::strtolower($key);
+        if ($normalizedKey === 'authorization' || strpos($normalizedKey, 'token') !== false) {
+            return '[filtered]';
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return '';
+        }
+
+        if (Tools::strlen($trimmed) > 160) {
+            return Tools::substr($trimmed, 0, 157) . '...';
+        }
+
+        return $trimmed;
+    }
+}


### PR DESCRIPTION
## Summary
- add a centralized GlobalPost error mapper and propagate the mapped codes/messages through shipment creation and document downloads
- validate shipment contact data before calling the API, mask additional PII in stored payload logs and surface detailed admin feedback
- expose a debug logging toggle wired to a sanitized PrestaShop logger adapter, update docs with handled codes and refreshed log sample

## Testing
- php -l modules/globalpostshipping/globalpostshipping.php
- phpunit --bootstrap tests/bootstrap.php tests *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68cd278916b883239147410369272d30