### PR TITLE
Remove bundled archive and document packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /vendor/
 modules/globalpostshipping/vendor/
 modules/globalpostshipping/composer.lock
-*.zip
+dist/*.zip
 *.tar
 .idea/
 .DS_Store

--- a/modules/globalpostshipping/README.md
+++ b/modules/globalpostshipping/README.md
@@ -48,6 +48,16 @@ composer install
 
 This command will generate the `vendor/` folder and the Composer autoloader used by PrestaShop when loading the module classes.
 
+## Packaging for Releases
+
+Create the installable archive locally once your changes are merged by running the following from the repository root:
+
+```bash
+zip -r dist/globalpostshipping.zip modules/globalpostshipping
+```
+
+The generated ZIP should be attached to your release or deployment channel (e.g. uploaded to a GitHub release) and must not be committed back into the Git repository.
+
 ## License
 
 This module is released under the Academic Free License 3.0 (AFL-3.0).

--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,13 @@ This repository contains the source code for the **GlobalPost Shipping** PrestaS
 - Documentation and SQL schema dump for onboarding
 
 Refer to [`modules/globalpostshipping/README.md`](modules/globalpostshipping/README.md) for installation and usage instructions.
+
+## Packaging the Module
+
+When you need an installable archive for QA or releases, generate it locally with the documented command:
+
+```bash
+zip -r dist/globalpostshipping.zip modules/globalpostshipping
+```
+
+Run the command from the repository root after your changes are merged. Attach the resulting ZIP to the release process (for example, a GitHub release asset or deployment ticket) instead of committing it to the repository.


### PR DESCRIPTION
## Summary
- restore the `.gitignore` entry to ignore `dist` ZIP artifacts instead of tracking them in Git
- document the local `zip -r dist/globalpostshipping.zip modules/globalpostshipping` packaging command in both READMEs so installers generate the archive themselves and share it outside of the repo

## Testing
- not run (documentation and ignore list updates)


------
https://chatgpt.com/codex/tasks/task_b_68cd2e4030548323bf63c1828f7814b3