### PR TITLE
Ensure DatabaseInstaller is loadable

### DIFF
--- a/modules/globalpostshipping/globalpostshipping.php
+++ b/modules/globalpostshipping/globalpostshipping.php
@@ -338,6 +338,8 @@ class Globalpostshipping extends CarrierModule
      */
     private function getDatabaseInstaller(): DatabaseInstaller
     {
+        require_once _PS_MODULE_DIR_ . 'globalpostshipping/src/Installer/DatabaseInstaller.php';
+
         return new DatabaseInstaller(Db::getInstance(), _DB_PREFIX_, _MYSQL_ENGINE_);
     }
 


### PR DESCRIPTION
## Summary
- require the DatabaseInstaller class before instantiating it so module installation can locate the class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cd375186ec8323b1d287b1340e8777