### PR TITLE
Fix missing carrier default flag in settings view

### DIFF
--- a/modules/globalpostshipping/views/templates/admin/form.tpl
+++ b/modules/globalpostshipping/views/templates/admin/form.tpl
@@ -1,0 +1,56 @@
+{if isset($globalpost_carriers) && $globalpost_carriers|@count > 0}
+<div class="card mt-3">
+  <div class="card-header">
+    <h3 class="card-title mb-0">{$globalpost_carriers_labels.title|escape:'html':'UTF-8'}</h3>
+  </div>
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table mb-0">
+        <thead>
+          <tr>
+            <th>{$globalpost_carriers_labels.type|escape:'html':'UTF-8'}</th>
+            <th>{$globalpost_carriers_labels.id|escape:'html':'UTF-8'}</th>
+            <th>{$globalpost_carriers_labels.name|escape:'html':'UTF-8'}</th>
+            <th>{$globalpost_carriers_labels.delay|escape:'html':'UTF-8'}</th>
+            <th>{$globalpost_carriers_labels.default|escape:'html':'UTF-8'}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {foreach from=$globalpost_carriers item=carrier}
+            <tr{if !empty($carrier.missing)} class="table-warning"{/if}>
+              <td>{$carrier.type_label|escape:'html':'UTF-8'}</td>
+              <td>{if !empty($carrier.id_carrier)}{$carrier.id_carrier|escape:'html':'UTF-8'}{else}&mdash;{/if}</td>
+              <td>
+                {if !empty($carrier.missing)}
+                  <span class="badge badge-warning">{$globalpost_carriers_labels.missing|escape:'html':'UTF-8'}</span>
+                {elseif !empty($carrier.name)}
+                  {$carrier.name|escape:'html':'UTF-8'}
+                {else}
+                  &mdash;
+                {/if}
+              </td>
+              <td>{if !empty($carrier.delay)}{$carrier.delay|escape:'html':'UTF-8'}{else}&mdash;{/if}</td>
+              <td>
+                {if $carrier.is_default|default:false}
+                  <span class="badge badge-success">{$globalpost_carriers_labels.default_yes|escape:'html':'UTF-8'}</span>
+                {else}
+                  <span class="badge badge-secondary">{$globalpost_carriers_labels.default_no|escape:'html':'UTF-8'}</span>
+                {/if}
+              </td>
+            </tr>
+          {/foreach}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {if $globalpost_carriers_missing}
+    <div class="card-footer">
+      <div class="alert alert-warning mb-0">{$globalpost_carriers_labels.missing|escape:'html':'UTF-8'}</div>
+    </div>
+  {/if}
+</div>
+{elseif isset($globalpost_carriers_labels)}
+  <div class="alert alert-info mt-3">
+    {$globalpost_carriers_labels.empty|escape:'html':'UTF-8'}
+  </div>
+{/if}


### PR DESCRIPTION
## Summary
- add configuration carrier summary context with fallback default flag values
- render a dedicated admin template that safely checks the carrier `is_default` flag
- explicitly set the module carriers as non-default when they are created

## Testing
- php -l modules/globalpostshipping/globalpostshipping.php

------
https://chatgpt.com/codex/tasks/task_b_68cd381d789c8323babf56cf58ec5832