### PR TITLE
Ensure DatabaseInstaller is available during install

### DIFF
--- a/modules/globalpostshipping/globalpostshipping.php
+++ b/modules/globalpostshipping/globalpostshipping.php
@@ -15,6 +15,8 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
 }
 
+require_once __DIR__ . '/src/Installer/DatabaseInstaller.php';
+
 use GlobalPostShipping\Error\ErrorMapper;
 use GlobalPostShipping\Installer\DatabaseInstaller;
 use GlobalPostShipping\Logger\PrestaShopLoggerAdapter;


### PR DESCRIPTION
## Summary
- ensure the module always loads the DatabaseInstaller class during install by requiring the installer file when composer autoloading is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cd55c323088323a1ae060f016cec0e