### PR TITLE
Fix default carrier warning in settings

### DIFF
--- a/modules/globalpostshipping/globalpostshipping.php
+++ b/modules/globalpostshipping/globalpostshipping.php
@@ -3010,6 +3010,7 @@ class Globalpostshipping extends CarrierModule
     private function buildCarrierSummaryForSettings(): array
     {
         $summary = [];
+        $defaultCarrierId = (int) Configuration::get('PS_CARRIER_DEFAULT');
 
         foreach (self::SUPPORTED_SHIPMENT_TYPES as $type) {
             $carrierId = $this->getCarrierIdForType($type);
@@ -3019,7 +3020,7 @@ class Globalpostshipping extends CarrierModule
                 'id_carrier' => $carrierId,
                 'name' => '',
                 'delay' => '',
-                'is_default' => false,
+                'is_default' => 0,
                 'missing' => true,
             ];
 
@@ -3034,7 +3035,7 @@ class Globalpostshipping extends CarrierModule
                         $carrierData['delay'] = (string) $carrier->delay[$languageId];
                     }
 
-                    $carrierData['is_default'] = (bool) ($carrier->is_default ?? false);
+                    $carrierData['is_default'] = ((int) $carrier->id === $defaultCarrierId) ? 1 : 0;
                     $carrierData['missing'] = false;
                 }
             }

--- a/modules/globalpostshipping/views/templates/admin/form.tpl
+++ b/modules/globalpostshipping/views/templates/admin/form.tpl
@@ -31,7 +31,8 @@
               </td>
               <td>{if !empty($carrier.delay)}{$carrier.delay|escape:'html':'UTF-8'}{else}&mdash;{/if}</td>
               <td>
-                {if $carrier.is_default|default:false}
+                {assign var=isDefault value=$carrier.is_default|default:0}
+                {if $isDefault}
                   <span class="badge badge-success">{$globalpost_carriers_labels.default_yes|escape:'html':'UTF-8'}</span>
                 {else}
                   <span class="badge badge-secondary">{$globalpost_carriers_labels.default_no|escape:'html':'UTF-8'}</span>


### PR DESCRIPTION
## Summary
- ensure the carrier summary always populates the `is_default` flag by comparing against the PrestaShop default carrier
- render the default status column via a safe Smarty assignment to avoid undefined key warnings

## Testing
- php -l modules/globalpostshipping/globalpostshipping.php

------
https://chatgpt.com/codex/tasks/task_b_68cd951d1f588323ac7e4e8a1794977d